### PR TITLE
dirname option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0
+
+- Add a `--dirname` option to extract, which outputs just the directory instead of a comma-separated list of files within the directory

--- a/bin/bundle-fairy.js
+++ b/bin/bundle-fairy.js
@@ -9,6 +9,7 @@ function usage() {
   console.error('');
   console.error('Options:');
   console.error(' -o, --outfile: specify an output file path');
+  console.error(' -d, --dirname: (only for extract) output just the directory name instead of a list of bundled files');
   console.error(' -v, --verbose: verbose error messages');
   console.error(' -h, --help: show this message');
   console.error('');
@@ -33,10 +34,13 @@ var zipfile = args._[1];
 if (!zipfile) { usage_and_exit('No zipfile.'); }
 if (!fs.existsSync(zipfile)) { usage_and_exit('Zipfile does not exist: ' + zipfile); }
 
+var options = {};
+options.dirname = args.d || args.dirname || false;
+
 //result:
 //* true|false if command is 'isbundle'
 //* [] of extracted file names/layers
-fairy[cmd](zipfile, function(err, result) {
+fairy[cmd](zipfile, options, function(err, result) {
   if (err) return fail(err);
   console.log(result);
 });

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var mkdirp = require('mkdirp');
 module.exports.isbundle = isbundle;
 module.exports.extract = extract;
 
-function isbundle(zipfile, callback) {
+function isbundle(zipfile, options, callback) {
 
   /*
   Assumptions:
@@ -33,6 +33,8 @@ function isbundle(zipfile, callback) {
   430bc2fe1cf6903d/layer2.geojson
   430bc2fe1cf6903d/layer2.geojson.index
    */
+
+  if (typeof options === 'function') callback = options;
 
   var allowed_files = ['.geojson', '.csv', '.index', '.json', '.kml', '.gpx'];
 
@@ -151,13 +153,17 @@ function isbundle(zipfile, callback) {
   });
 }
 
-function extract(zipfile, callback) {
+function extract(zipfile, options, callback) {
+
+  if (typeof options === 'function') callback = options;
+
   isbundle(zipfile, function(err) {
     if (err) return callback(err);
 
     var extract_dir = path.join(path.dirname(path.resolve(zipfile)), crypto.randomBytes(8).toString('hex'));
     var zf = new zip.ZipFile(zipfile);
     var layer_files = [];
+
     zf.names.forEach(function(zip_entry) {
       var out_file = path.join(extract_dir, zip_entry);
       if (zip_entry.lastIndexOf('/') === zip_entry.length - 1) {
@@ -169,7 +175,9 @@ function extract(zipfile, callback) {
         }
       }
     });
-    callback(null, layer_files.join(','));
+
+    if (options && options.dirname) return callback(null, extract_dir);
+    return callback(null, layer_files.join(','));
   });
 }
 

--- a/readme.md
+++ b/readme.md
@@ -58,29 +58,37 @@ fairy.isBundle('./path/to/file.zip', function(err, isbundle) {
 
 #### extract a bundle, `extract()`
 ```javascript
-// ***** exact output of this function is yet to be determined *****
-
-fairy.isBundle('./path/to/file.zip', function(err, uri) {
+fairy.extract('./path/to/file.zip', function(err, result) {
   if (err) throw err;
-  console.log(uri); // uri string to extracted directory
+  console.log(result); // comma separated list of files within the bundle
+});
+```
+
+You can pass in the `dirname` option to just get the full directory path back:
+
+```javascript
+fairy.extract('./path/to/file.zip', { dirname: true }, function(err, result) {
+  if (err) throw err;
+  console.log(result); // /User/waka/files/tmp-bundle
 });
 ```
 
 ### CLI Usage
 
 **Check if is bundle**
-```
+```shell
 $ bundle-fairy isbundle <zipfile>
 ```
 
 **Extract bundle**
-```
+```shell
 $ bundle-fairy extract <zipfile>
+$ bundle-fairy extract <zipfile> --dirname # returns just directory name
 ```
 
 # Test
 
-```bash
+```shell
 npm test
 ```
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,6 +4,18 @@ var fixtures = require('./fixtures');
 var expectations = require('./expectations');
 var queue = require('queue-async');
 var rimraf = require('rimraf');
+var exec = require('child_process').exec;
+
+function cleanup(layers, assert) {
+  var parts = layers[0].split('/');
+  var tmp = parts[parts.indexOf('fixtures') + 1];
+  var tmpdir = layers[0].split(tmp)[0] + tmp;
+
+  rimraf(tmpdir, function(err) {
+    if (err) throw err;
+    assert.end();
+  });
+}
 
 test('valid bundles', function(t) {
   var q = queue();
@@ -59,18 +71,7 @@ test('extract: single csv layer', function(t) {
     t.equal(layers.length, 1, 'expected number of layers');
     t.true(output.indexOf('bundle_single-csv-with-index/states.sm.csv') > -1, 'outputs expected layer(s)');
 
-    cleanup(layers);
-
-    function cleanup(layers) {
-      var parts = layers[0].split('/');
-      var tmp = parts[parts.indexOf('fixtures') + 1];
-      var tmpdir = layers[0].split(tmp)[0] + tmp;
-
-      rimraf(tmpdir, function(err) {
-        if (err) throw err;
-        t.end();
-      });
-    }
+    cleanup(layers, t);
   });
 });
 
@@ -82,18 +83,7 @@ test('extract: single geojson layer', function(t) {
     t.equal(layers.length, 1, 'expected number of layers');
     t.true(output.indexOf('bundle_single-geojson-with-metadata-without-index/states-1.geojson') > -1, 'outputs expected layer(s)');
 
-    cleanup(layers);
-
-    function cleanup(layers) {
-      var parts = layers[0].split('/');
-      var tmp = parts[parts.indexOf('fixtures') + 1];
-      var tmpdir = layers[0].split(tmp)[0] + tmp;
-
-      rimraf(tmpdir, function(err) {
-        if (err) throw err;
-        t.end();
-      });
-    }
+    cleanup(layers, t);
   });
 });
 
@@ -105,17 +95,59 @@ test('extract: multiple geojson layers', function(t) {
     t.equal(layers.length, 2, 'expected number of layers');
     t.true(output.indexOf('bundle_geojson-with-indices-and-metadata/states-1.geojson') > -1, 'outputs expected layer(s)');
 
-    cleanup(layers);
+    cleanup(layers, t);
+  });
+});
 
-    function cleanup(layers) {
-      var parts = layers[0].split('/');
-      var tmp = parts[parts.indexOf('fixtures') + 1];
-      var tmpdir = layers[0].split(tmp)[0] + tmp;
+test('extract: options.dirname', function(t) {
+  fairy.extract(fixtures.valid.single_csv_withindex, { dirname: true }, function(err, output) {
+    if (err) throw err;
+    t.ok(output.length > 0, 'output has length');
+    t.ok(output.indexOf('fixtures') > -1, 'output has fixtures in path');
+    t.ok(output.indexOf('/') === 0, 'absolute path');
+    rimraf(output, function(err) {
+      if (err) throw err;
+      t.end();
+    });
+  });
+});
 
-      rimraf(tmpdir, function(err) {
-        if (err) throw err;
-        t.end();
-      });
-    }
+test('[bin] isBundle', function(t) {
+  var path = fixtures.valid.geojson_withindex_withmetadata;
+  exec('node ' + __dirname + '/../bin/bundle-fairy isBundle ' + path, function(err, stdout, stderr) {
+    if (err) t.fail();
+    t.equal(stderr, '', 'no stderr');
+    t.equal(stdout, 'true\n', 'stdout is true');
+    t.end();
+  });
+});
+
+test('[bin] extract', function(t) {
+  var path = fixtures.valid.geojson_withindex_withmetadata;
+  exec('node ' + __dirname + '/../bin/bundle-fairy extract ' + path, function(err, stdout, stderr) {
+    if (err) t.fail();
+
+    var layers = stdout.split(',');
+    t.equal(layers.length, 2, 'expected number of layers');
+    t.equal(stderr, '', 'no stderr');
+    t.ok(stdout.length > 0, 'stdout has length');
+    t.ok(stdout.indexOf(',') > -1, 'stdout has commas');
+
+    cleanup(layers, t);
+  });
+});
+
+test('[bin] extract --dirname flag', function(t) {
+  var path = fixtures.valid.geojson_withindex_withmetadata;
+  exec('node ' + __dirname + '/../bin/bundle-fairy extract ' + path + ' --d', function(err, stdout, stderr) {
+    if (err) t.fail();
+    t.equal(stderr, '', 'no stderr');
+    t.ok(stdout.length > 0, 'stdout has length');
+    t.ok(stdout.indexOf(',') === -1, 'stdout has no commas');
+    t.ok(stdout.indexOf('fixtures') > -1);
+    rimraf(stdout.replace('\n', ''), function(err) {
+      if (err) throw err;
+      t.end();
+    });
   });
 });


### PR DESCRIPTION
This adds an options object to each method (prepare us for the future) and brings in a new parameter `dirname` used specifically within `extract()` that outputs just the extracted directory path rather than the comma-separated list of files within that path.

cc @GretaCB @who8mycakes 